### PR TITLE
Send repeat info when binding a keyboard resource

### DIFF
--- a/src/client/qwaylanddisplay.cpp
+++ b/src/client/qwaylanddisplay.cpp
@@ -375,6 +375,11 @@ bool QWaylandDisplay::supportsWindowDecoration() const
     return integrationSupport;
 }
 
+QWaylandWindow *QWaylandDisplay::lastInputWindow() const
+{
+    return mLastInputWindow.data();
+}
+
 void QWaylandDisplay::setLastInputDevice(QWaylandInputDevice *device, uint32_t serial, QWaylandWindow *win)
 {
     mLastInputDevice = device;

--- a/src/client/qwaylanddisplay_p.h
+++ b/src/client/qwaylanddisplay_p.h
@@ -36,6 +36,7 @@
 
 #include <QtCore/QObject>
 #include <QtCore/QRect>
+#include <QtCore/QPointer>
 
 #include <QtCore/QWaitCondition>
 
@@ -157,7 +158,7 @@ public:
 
     uint32_t lastInputSerial() const { return mLastInputSerial; }
     QWaylandInputDevice *lastInputDevice() const { return mLastInputDevice; }
-    QWaylandWindow *lastInputWindow() const { return mLastInputWindow; }
+    QWaylandWindow *lastInputWindow() const;
     void setLastInputDevice(QWaylandInputDevice *device, uint32_t serial, QWaylandWindow *window);
 
 public slots:
@@ -202,7 +203,7 @@ private:
     int mCompositorVersion;
     uint32_t mLastInputSerial;
     QWaylandInputDevice *mLastInputDevice;
-    QWaylandWindow *mLastInputWindow;
+    QPointer<QWaylandWindow> mLastInputWindow;
 
     void registry_global(uint32_t id, const QString &interface, uint32_t version) Q_DECL_OVERRIDE;
     void registry_global_remove(uint32_t id) Q_DECL_OVERRIDE;

--- a/src/client/qwaylandinputdevice.cpp
+++ b/src/client/qwaylandinputdevice.cpp
@@ -594,12 +594,29 @@ static const uint32_t KeyTbl[] = {
     XKB_KEY_Mode_switch,             Qt::Key_Mode_switch,
     XKB_KEY_script_switch,           Qt::Key_Mode_switch,
 
+    XKB_KEY_XF86Back,                Qt::Key_Back,
+    XKB_KEY_XF86Forward,             Qt::Key_Forward,
+
     XKB_KEY_XF86AudioPlay,           Qt::Key_MediaTogglePlayPause, //there isn't a PlayPause keysym, however just play keys are not common
     XKB_KEY_XF86AudioPause,          Qt::Key_MediaPause,
     XKB_KEY_XF86AudioStop,           Qt::Key_MediaStop,
     XKB_KEY_XF86AudioPrev,           Qt::Key_MediaPrevious,
     XKB_KEY_XF86AudioNext,           Qt::Key_MediaNext,
+    XKB_KEY_XF86AudioRewind,         Qt::Key_MediaPrevious,
+    XKB_KEY_XF86AudioForward,        Qt::Key_MediaNext,
     XKB_KEY_XF86AudioRecord,         Qt::Key_MediaRecord,
+
+    XKB_KEY_XF86AudioMute,           Qt::Key_VolumeMute,
+    XKB_KEY_XF86AudioLowerVolume,    Qt::Key_VolumeDown,
+    XKB_KEY_XF86AudioRaiseVolume,    Qt::Key_VolumeUp,
+
+    XKB_KEY_XF86AudioRandomPlay,     Qt::Key_AudioRandomPlay,
+    XKB_KEY_XF86AudioRepeat,         Qt::Key_AudioRepeat,
+
+    XKB_KEY_XF86ZoomIn,              Qt::Key_ZoomIn,
+    XKB_KEY_XF86ZoomOut,             Qt::Key_ZoomOut,
+
+    XKB_KEY_XF86Eject,               Qt::Key_Eject,
 
     0,                          0
 };

--- a/src/compositor/wayland_wrapper/qwlkeyboard.cpp
+++ b/src/compositor/wayland_wrapper/qwlkeyboard.cpp
@@ -184,10 +184,14 @@ QtWaylandServer::wl_keyboard::Resource *Keyboard::focusResource() const
 
 void Keyboard::keyboard_bind_resource(wl_keyboard::Resource *resource)
 {
+    // Set the repeat info, using the default values from weston.ini
+    send_repeat_info(resource->handle, 40, 400); 
+
 #ifndef QT_NO_WAYLAND_XKB
     if (m_context) {
         send_keymap(resource->handle, WL_KEYBOARD_KEYMAP_FORMAT_XKB_V1,
                     m_keymap_fd, m_keymap_size);
+
         return;
     }
 #endif

--- a/src/qtwaylandscanner/qtwaylandscanner.cpp
+++ b/src/qtwaylandscanner/qtwaylandscanner.cpp
@@ -88,6 +88,7 @@ struct WaylandArgument {
 struct WaylandEvent {
     bool request;
     QByteArray name;
+    QByteArray type;
     QList<WaylandArgument> arguments;
 };
 
@@ -124,6 +125,7 @@ WaylandEvent readEvent(QXmlStreamReader &xml, bool request)
     WaylandEvent event;
     event.request = request;
     event.name = byteArrayValue(xml, "name");
+    event.type = byteArrayValue(xml, "type");
     while (xml.readNextStartElement()) {
         if (xml.name() == "arg") {
             WaylandArgument argument;
@@ -998,6 +1000,8 @@ void process(QXmlStreamReader &xml, const QByteArray &headerPath, const QByteArr
                     }
                 }
                 printf(");\n");
+                if (e.type == "destructor")
+                    printf("        m_%s = 0;\n", interfaceName);
                 printf("    }\n");
             }
 


### PR DESCRIPTION
The problem was that your patch only set up the protocol - the repeat info was never actually set up.
- Use the default values from `weston.ini` for some reasonal repeat times.
- Fixes greenisland/greenisland#79
